### PR TITLE
Add option for static IP configuration

### DIFF
--- a/firmware_mod/config/resolv.conf.dist
+++ b/firmware_mod/config/resolv.conf.dist
@@ -1,0 +1,20 @@
+## An example resolv.conf to use with static IP configuration
+## This file is only relevant when a static address is configured
+## Otherwise, resolv.conf is managed by DHCP
+## Uncomment lines as needed, everything is optional
+
+## Detailed documentation:
+## https://linux.die.net/man/5/resolv.conf
+
+## List DNS server addresses, primary, secondary, etc
+#nameserver 192.168.1.1
+#nameserver 192.168.1.2
+#nameserver 192.168.1.3
+
+## Domain of this system
+## Determined automatically from fully-qualified hostname when unspecified
+#domain myteam.myorg.mycorp.net
+
+## Search list to resolves unqualified hostnames
+## Defaults to domain when unspecified
+#search myteam.myorg.mycorp.net myorg.mycorp.net mycorp.net

--- a/firmware_mod/config/staticip.conf.dist
+++ b/firmware_mod/config/staticip.conf.dist
@@ -1,0 +1,2 @@
+# IP address and subnet mask
+192.168.1.2 255.255.255.0

--- a/firmware_mod/run.sh
+++ b/firmware_mod/run.sh
@@ -100,13 +100,14 @@ if [ ! -f $CONFIGPATH/hostname.conf ]; then
 fi
 hostname -F $CONFIGPATH/hostname.conf
 
+## Load network driver
 if [ -f $CONFIGPATH/usb_eth_driver.conf ]; then
   ## Start USB Ethernet:
   echo "USB_ETHERNET: Detected USB config. Loading USB Ethernet driver" >> $LOGPATH
   insmod /system/sdcard/driver/usbnet.ko
   insmod /system/sdcard/driver/asix.ko
-  ifconfig eth0 up
-  udhcpc_status=$(udhcpc -i eth0 -p /var/run/udhcpc.pid -b -x hostname:"$(hostname)")
+
+  network_interface_name="eth0"
 else
   ## Start Wifi:
   if [ ! -f $CONFIGPATH/wpa_supplicant.conf ]; then
@@ -125,10 +126,28 @@ else
   fi
   wpa_supplicant_status="$(wpa_supplicant -d -B -i wlan0 -c $CONFIGPATH/wpa_supplicant.conf -P /var/run/wpa_supplicant.pid)"
   echo "wpa_supplicant: $wpa_supplicant_status" >> $LOGPATH
-  udhcpc_status=$(udhcpc -i wlan0 -p /var/run/udhcpc.pid -b -x hostname:"$(hostname)")
+
+  network_interface_name="wlan0"
 fi
 
-echo "udhcpc: $udhcpc_status" >> $LOGPATH
+## Configure network address
+if [ -f "$CONFIGPATH/staticip.conf" ]; then
+  # Install a resolv.conf if present so DNS can work
+  if [ -f "$CONFIGPATH/resolv.conf" ]; then
+    cp "$CONFIGPATH/resolv.conf" /etc/resolv.conf
+  fi
+
+  # Configure staticip/netmask from config/staticip.conf
+  staticip_and_netmask=$(cat "$CONFIGPATH/staticip.conf" | grep -v "^$" | grep -v "^#")
+  ifconfig "$network_interface_name" $staticip_and_netmask
+  ifconifg "$network_interface_name" up
+  echo "Configured $network_interface_name with static address $staticip_and_netmask" >> $LOGPATH
+else
+  # Configure with DHCP client
+  ifconifg "$network_interface_name" up
+  udhcpc_status=$(udhcpc -i "$network_interface_name" -p /var/run/udhcpc.pid -b -x hostname:"$(hostname)")
+  echo "udhcpc: $udhcpc_status" >> $LOGPATH
+fi
 
 ## Set Timezone
 set_timezone


### PR DESCRIPTION
Configure static IP and netmask when config/staticip.conf is present.
Add config/staticip.conf.dist example.

Additionally, configure a static resolv.conf when config/resolv.conf
is also present (in addition to config/staticip.conf). This is normally
configured by DHCP. Add config/resolv.conf.dist example.

Tested both DHCP and static IP configs over Wifi on Wyze Cam V2.